### PR TITLE
Running scripts: fix separator comment

### DIFF
--- a/run_game.sh
+++ b/run_game.sh
@@ -38,7 +38,7 @@ run_option4() {
   vblank_mode=0 "./SeriousSam"
 }
 
-Launcher
+# Launcher
 echo "Running ${GAME_NAME} launcher"
  
 option1="Run Serious Sam TFE Classic (Lock 60fps)"

--- a/run_game_hud.sh
+++ b/run_game_hud.sh
@@ -38,7 +38,7 @@ run_option4() {
   vblank_mode=0 MANGOHUD_CONFIG="offset_y=75,offset_x=20,cpu_temp,gpu_temp,ram,vram,engine_version" mangohud --dlsym "./SeriousSam"
 }
 
-Launcher
+# Launcher
 echo "Running ${GAME_NAME} launcher"
  
 option1="Run Serious Sam TFE Classic (Lock 60fps)"

--- a/run_server.sh
+++ b/run_server.sh
@@ -33,7 +33,7 @@ run_option4() {
   "nano" "${CURRENT_DIR}/SamTSE/Scripts/Dedicated/DefaultCoop/init.ini"
 }
 
-Launcher
+# Launcher
 echo "Running ${GAME_NAME} launcher"
  
 option1="Serious Sam TFE Classic (Start Dedicated Server)"


### PR DESCRIPTION
Noted when running those scripts and get the following message:

"./run_game.sh: line 41: Launcher: command not found"

