### PR TITLE
Replace patches url to archive.org

### DIFF
--- a/build-linux64demo.sh
+++ b/build-linux64demo.sh
@@ -7,7 +7,7 @@
 cd SamTFE
 mv Scripts/GLSettings Scripts/GLSettings_new
 wget https://archive.org/download/SeriousSamDemo/SeriousSamDemo.exe
-wget http://www.cngwireless.net/apps/Game%20Patches/serioussampatch105_usa.exe
+wget https://archive.org/download/SeriousSamPatches/serioussampatch105_usa.exe
 7z x SeriousSamDemo.exe
 7z x -y serioussampatch105_usa.exe
 rm -fr Scripts/GLSettings
@@ -30,7 +30,7 @@ cd ..
 cd SamTSE
 mv Scripts/GLSettings Scripts/GLSettings_new
 wget https://archive.org/download/serioussamsedemo/SeriousSamSEDemo.exe
-wget http://www.cngwireless.net/apps/Game%20Patches/secondencounterpatch107_usa.exe
+wget https://archive.org/download/SeriousSamPatches/secondencounterpatch107_usa.exe
 7z x SeriousSamSEDemo.exe
 7z x -y secondencounterpatch107_usa.exe
 rm -fr Scripts/GLSettings


### PR DESCRIPTION
http://www.cngwireless.net/ - is down:
https://downforeveryoneorjustme.com/cngwireless.net?www=1

So, it's better to use same archive.org for demos and patches.